### PR TITLE
Fix mapbox webpack

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -63,5 +63,11 @@ module.exports = {
         }
       }
     ]
-  }
+  },
+
+  // Mapbox has bundling issues with webpack so ignore it
+  // and expect it to be loaded by the client in the script tags
+  externals: {
+       "mapbox-gl": 'mapboxgl'
+   }
 }

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <!-- Reference the mapboxgl scripts here because webpack generated bundle expects it here -->
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.36.0/mapbox-gl.js'></script>
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.14.2/mapbox-gl.css' rel='stylesheet' />
     <link rel="stylesheet" href="http://localhost:5000/assets/css/semantic-ui.min.css">
     <title>transcriptus-ui</title>

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -78,7 +78,7 @@
         </div><!--/ The soldStands menu item -->
 
         <!-- Other menu items will come down here -->
-        <a class="item" @click="fetchReservedStands">Reserved Stands</a>
+
       </div>
     </div>
 


### PR DESCRIPTION
This PR contains code that fixes the error ```ReferenceError: e is not defined``` that shows in the browser after bundling mapbox-gl with webpack.

**Changes**

* Do not bundle mapbox with webpack. Expect it to be in the window object
* Reference mapbox-gl in the script tags in the index.html file